### PR TITLE
Add return_path field to scripting request

### DIFF
--- a/carta_service.proto
+++ b/carta_service.proto
@@ -13,6 +13,7 @@ message ActionRequest {
     string action = 3;
     string parameters = 4;
     bool async = 5;
+    string return_path = 6;
 }
 
 // A response with the success status resulting from the action call, and a possible error message


### PR DESCRIPTION
Fixes a bug in the scripting interface by allowing the wrapper to request a subset of a called action's return value (which can be serialized correctly). Companion to PRs in the frontend, protobuf, wrapper and backend code.